### PR TITLE
Fix importing issue in the ConfigurationBuilder

### DIFF
--- a/cs_fmu_mapper/config.py
+++ b/cs_fmu_mapper/config.py
@@ -15,47 +15,54 @@ class ConfigurationBuilder:
     Configuration class for the cs-fmu-mapper.
 
     This class is responsible for loading and processing configuration files.
-    It supports both full configurations and component-specific configurations.
+    It supports both full configurations and modular configurations.
     """
 
     def __init__(
         self,
         config_file_path: Union[str, Path],
-        config_dir: Union[str, Path] = os.path.join(
+        module_dir: Union[str, Path] = os.path.join(
             Path(__file__).parent.parent, "example", "configs"
         ),
         settings_injections: dict[str, Any] = {},
         config_injections: dict[str, Any] = {},
     ):
-        self._config_dir = config_dir
-        self._config_injections = config_injections
-        self._env = Environment(loader=FileSystemLoader(self._config_dir))
-        self._config = OmegaConf.create()
-        self._settings_config = self._load_partial_settings(
-            Path(self._config_dir) / config_file_path
-        )
-        if settings_injections:
-            self._settings_config = self._handle_injections(
-                self._settings_config, settings_injections
-            )
-        try:
-            self._modular_config = self._settings_config.modular_config
-        except AttributeError:
-            self._modular_config = False
-        if self._modular_config:
-            self._handle_modular_config(config_file_path)
-        else:
-            self._handle_full_config()
-        if "modular_config" in self._config:
-            del self._config["modular_config"]
+        """
+        Initialize the ConfigurationBuilder.
 
-    def _handle_full_config(self):
-        print(
-            "No Components found in the config file. Assuming the provided config is a full config."
-        )
-        self._config = self._settings_config
+        ### Arguments:
+        - config_file_path: Relative or absolute path to the configuration file (Modular or Full config)
+        - module_dir: For modular configs: Directory containing the modular config files.
+        - settings_injections: Additional dictionary to inject into the settings config.
+        - config_injections: Additional dictionary to inject into the config before generating the mappings.
+        """
+        self._config_file_path = Path(config_file_path).resolve()
+        self._module_dir = Path(module_dir).resolve()
+
+        self._settings_injections = settings_injections
+        self._config_injections = config_injections
+
+        self._config = self._load_initial_config(self._config_file_path)
+
+        self._use_modular_config = self._config.setdefault("modular_config", False)
+
+        if self._use_modular_config:
+            self._settings_config = self._config
+            self._config = OmegaConf.create()
+
+        self._env = Environment()
+
+        if self._use_modular_config:
+            self._settings_config = self._handle_injections(
+                self._settings_config, self._settings_injections
+            )
+            self._handle_modular_config(self._config_file_path)
+
+        if "modular_config" in self._config:  # type: ignore
+            del self._config["modular_config"]  # type: ignore
 
     def _handle_modular_config(self, config_file_path: Union[str, Path]):
+        """Handle the modular configuration by loading component configs, merging files, and generating mappings."""
         for component, config_names in self._settings_config.Components.items():
             self._load_component_configs(component, config_names)
         self._merge_config(config_file_path)  # Apply overrides
@@ -70,15 +77,17 @@ class ConfigurationBuilder:
     def _load_component_configs(
         self, component: str, config_names: Union[str, ListConfig]
     ):
+        """Load the component configs from the modular config."""
         if isinstance(config_names, ListConfig):
             for config_name in config_names:
-                self._merge_config(f"{component}/{config_name}.yaml")
+                self._merge_config(f"{self._module_dir}/{component}/{config_name}.yaml")
         else:
-            self._merge_config(f"{component}/{config_names}.yaml")
+            self._merge_config(f"{self._module_dir}/{component}/{config_names}.yaml")
 
     def _handle_injections(
         self, config: DictConfig | ListConfig, injections: dict[str, Any]
     ) -> DictConfig | ListConfig:
+        """Merge the config with additional injections."""
         return OmegaConf.merge(
             config,
             OmegaConf.create(injections),
@@ -132,16 +141,7 @@ class ConfigurationBuilder:
         }
 
     def _assert_mapping_rule(self, rule: dict, prefix_rules: dict) -> None:
-        """
-        Assert that a mapping rule is valid.
-
-        Args:
-            rule (dict): The mapping rule to validate.
-            prefix_rules (dict): The prefix rules for components.
-
-        Raises:
-            AssertionError: If the rule is invalid.
-        """
+        """Assert that a mapping rule is valid."""
         if "source" in rule:
             assert (
                 isinstance(rule["source"], dict) and len(rule["source"]) == 1
@@ -170,35 +170,7 @@ class ConfigurationBuilder:
         ], f"Destination var_type must be 'outputVar' or 'inputVar', got '{dest_var_type}'"
 
     def _generate_mappings(self) -> None:
-        """
-        Generate a mapping of preStepMappings and postStepMappings from the configuration.
-
-        This method processes the MappingRules defined in the configuration to create
-        a mapping structure. It handles both preStepMappings and postStepMappings,
-        which define how variables should be mapped between different components.
-
-        The method performs the following steps:
-        1. Extracts mapping rules and prefix rules from the configuration.
-        2. Iterates through each component and its rules in the mapping rules.
-        3. Validates that components and variable types exist in the configuration.
-        4. Processes each rule to create source and destination keys.
-        5. Adds valid mappings to the mapper structure.
-
-        The method also includes several safety checks:
-        - It ignores components that are in MappingRules but not in the main configuration.
-        - It skips variable types that are not found in a component's configuration.
-        - It ignores rules where either the source or destination component is not in the configuration.
-
-        The resulting mapper is merged into the configuration under the "Mapping" key.
-
-        Note:
-        - This method modifies the internal _config attribute.
-        - It logs informational messages when ignoring rules due to missing components or variable types.
-
-        Raises:
-        - Any exceptions raised during the OmegaConf merge operation.
-        - KeyError if MappingRules, Components, or Prefix are not found in the configuration.
-        """
+        """Generate a mapping of preStepMappings and postStepMappings from the configuration."""
         mapper = OmegaConf.create({"preStepMappings": {}, "postStepMappings": {}})
 
         if "MappingRules" not in self._config:
@@ -277,20 +249,7 @@ class ConfigurationBuilder:
         )
 
     def _merge_config(self, config_path: Union[str, pathlib.Path, IO[Any]]) -> None:
-        """
-        Load a configuration file and merge it with the current combined configuration.
-
-        This method loads a configuration file using the _load_config method,
-        then merges it with the existing configuration using OmegaConf.merge.
-        The merge is performed with EXTEND_UNIQUE list merge mode to avoid duplicates.
-
-        Args:
-            config_path (Union[str, pathlib.Path, IO[Any]]): Path to the configuration
-                file or a file-like object containing the configuration.
-
-        Raises:
-            ValueError: If there's an error loading or merging the configuration.
-        """
+        """Load a configuration file and merge it with the current combined configuration."""
         try:
             component_config = self._load_config(str(config_path))
             self._config = OmegaConf.merge(
@@ -306,59 +265,26 @@ class ConfigurationBuilder:
     def _load_config(
         self, config_path: Union[str, pathlib.Path, IO[Any]]
     ) -> DictConfig | ListConfig:
-        """
-        Load and process a YAML configuration file with Jinja2 templating.
-
-        This method loads a YAML file, renders any Jinja2 templates within it
-        using the current combined configuration as context, and then creates
-        an OmegaConf configuration object from the rendered YAML.
-
-        Args:
-            config_path (Union[str, pathlib.Path, IO[Any]]): Path to the YAML
-                configuration file or a file-like object containing the configuration.
-
-        Returns:
-            DictConfig | ListConfig: An OmegaConf configuration object created
-            from the rendered YAML.
-
-        Raises:
-            jinja2.TemplateNotFound: If the template file cannot be found.
-            jinja2.TemplateError: If there's an error in the Jinja2 template.
-            OmegaConfBaseException: If there's an error creating the OmegaConf object.
-        """
+        """Load and process a YAML configuration file with Jinja2 templating."""
         try:
-            template = self._env.get_template(str(config_path))
+            with open(config_path, "r") as file:
+                yaml_content = file.read()
+
             context = {**self._config, "transform_vars": self.transform_vars}  # type: ignore
+            template = jinja2.Template(yaml_content)
             rendered_yaml = template.render(**context)
             return OmegaConf.create(rendered_yaml)
-        except jinja2.TemplateNotFound:
+        except FileNotFoundError:
             raise FileNotFoundError(f"Configuration file not found: {config_path}")
         except jinja2.TemplateError as e:
             raise ValueError(f"Error in Jinja2 template: {e}")
         except OmegaConfBaseException as e:
             raise ValueError(f"Error creating OmegaConf object: {e}")
 
-    def _load_partial_settings(
+    def _load_initial_config(
         self, settings_path: Union[str, pathlib.Path]
     ) -> DictConfig | ListConfig:
-        """
-        Load the initial part of a YAML configuration file.
-
-        This method reads the file up to a specific comment line, which separates
-        the component definitions from the rest of the configuration. This approach
-        allows for loading component information before processing Jinja2 templates
-        that may depend on these components.
-
-        Args:
-            settings_path (Union[str, pathlib.Path]): Path to the settings YAML file.
-
-        Returns:
-            DictConfig | ListConfig: Parsed configuration up to the separator comment.
-
-        Note:
-            The file should contain a line with the comment '# END_COMPONENT_DEFINITIONS'
-            after all component definitions. This line acts as a separator.
-        """
+        """Load the initial part of a YAML configuration file. Stops at `separator_comment`."""
         separator_comment = "# END_COMPONENT_DEFINITIONS"
 
         with open(settings_path, "r") as file:
@@ -378,7 +304,6 @@ class ConfigurationBuilder:
                 del self._config[key]  # type: ignore
 
     def get_config(self) -> dict[str, Any]:
-        """Returns the combined config from the settings and the Components."""
         return OmegaConf.to_container(self._config)  # type: ignore
 
     def save_to_yaml(self, path: Union[str, Path]):

--- a/cs_fmu_mapper/main.py
+++ b/cs_fmu_mapper/main.py
@@ -1,15 +1,17 @@
 #!/usr/bin/python
-from cs_fmu_mapper.opcua_fmu_mapper import OPCUAFMUMapper
-from cs_fmu_mapper.component_factory import ComponentFactory
+import argparse
 import asyncio
 import json
-import argparse
 import logging
-from contextlib import suppress
-import yaml
-import sys
 import os
+import sys
+from pathlib import Path
+from contextlib import suppress
+
+import yaml
+from cs_fmu_mapper.component_factory import ComponentFactory
 from cs_fmu_mapper.config import ConfigurationBuilder
+from cs_fmu_mapper.opcua_fmu_mapper import OPCUAFMUMapper
 
 os.environ["FOR_DISABLE_CONSOLE_CTRL_HANDLER"] = "1"
 
@@ -24,8 +26,6 @@ async def kill_tasks():
         with suppress(asyncio.CancelledError):
             await task
 
-
-print(os.getcwd())
 
 # setup logging
 logging.basicConfig(
@@ -43,24 +43,14 @@ parser.add_argument(
     "--config_path",
     help="Path to config file which defines OPCUA server information, node mapping and optionally Modelica simulation setup.",
     type=str,
-    default="config.yaml",
-)
-parser.add_argument(
-    "-b",
-    "--use_config_builder",
-    help="Set this flag to use config builder.",
-    action="store_true",
-    default=False,
+    default=Path(__file__).parent.parent / "example" / "configs" / "config.yaml",
 )
 
 args = parser.parse_args()
 
 logger.info("Reading configuration file...")
-if args.use_config_builder:
-    config = ConfigurationBuilder(config_file_path=args.config_path).get_config()
-else:
-    with open(args.config_path, "r") as file:
-        config = yaml.safe_load(file)
+
+config = ConfigurationBuilder(config_file_path=args.config_path).get_config()
 
 logger.info("Creating PLCClient, FMU Simualation and Mapper Instance...")
 master = ComponentFactory().createComponents(config)

--- a/cs_fmu_mapper/utils.py
+++ b/cs_fmu_mapper/utils.py
@@ -2,11 +2,11 @@ import inquirer
 import os
 
 
-def chooseFile(path, messsage):
+def chooseFile(path, message):
     if not os.path.exists(path):
         raise FileNotFoundError("Path does not exist: " + path)
 
     files = [f for f in os.listdir(path) if os.path.isfile(os.path.join(path, f))]
-    questions = [inquirer.List("file", message=messsage, choices=files)]
+    questions = [inquirer.List("file", message=message, choices=files)]
     answers = inquirer.prompt(questions)
     return answers["file"]

--- a/example/configs/config.yaml
+++ b/example/configs/config.yaml
@@ -13,7 +13,7 @@ Master:
 Model:
   type: fmu-pyfmi #or fmu-fmpy
   path: example/fmu/
-  numberOfStepsPerCycle: 1
+  stepSize: 0.01
   inputVar:
     model.in.u:
       init: 0


### PR DESCRIPTION
# Configuration Handling Improvements and Bug Fix

This pull request addresses the importing issue described in #11

## Key Changes

### 1. Configuration Handling Overhaul
- Renamed `config_dir` to `module_dir` for clarity
- Improved initialization process and modular configuration handling
- Modified config import mechanism:
  - `config_file_path` is now independent of `module_dir`
  - Config (full or modular) is imported solely using `config_file_path`
  - `module_dir` is only necessary for modular configs (settings files)
  - For modular configs, `module_dir` specifies the location of component modules

### 2. Documentation Improvements
- Simplified and shortened docstrings in `cs_fmu_mapper/config.py` to enhance readability

### 3. Bug Fix
- Resolved the importing issue detailed in #11